### PR TITLE
Configure clickhouse connection pooling

### DIFF
--- a/pkg/providers/clickhouse/conn/connection.go
+++ b/pkg/providers/clickhouse/conn/connection.go
@@ -38,7 +38,15 @@ func ConnectNative(host string, cfg ConnParams, hosts ...string) (*sql.DB, error
 	if err != nil {
 		return nil, err
 	}
-	return clickhouse.OpenDB(opts), nil
+
+	db := clickhouse.OpenDB(opts)
+
+	// OpenDB suggests it's the caller's responsibility to configure the connection pool, so we must set it to reasonable defaults for long-running jobs.
+	// FIXME: make these configurable
+	db.SetMaxOpenConns(50)
+	db.SetMaxIdleConns(20)
+	db.SetConnMaxLifetime(30 * time.Minute)
+	db.SetConnMaxIdleTime(10 * time.Minute)
 }
 
 func GetClickhouseOptions(cfg ConnParams, hosts []string) (*clickhouse.Options, error) {


### PR DESCRIPTION
[OpenDB](https://github.com/ClickHouse/clickhouse-go/blob/b66234469b8bd16ca99e0b3dbf999b1ab0184d0d/clickhouse_std.go#L161) suggests it's the caller's responsibility to configure the connection pool, so we must set it to reasonable defaults for long-running jobs.


(Draft as I'm still testing)