### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/vendor_patched/github.com/segmentio/kafka-go/docker-compose.yml
+++ b/vendor_patched/github.com/segmentio/kafka-go/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       ALLOW_ANONYMOUS_LOGIN: yes
   kafka:
     container_name: kafka
-    image: bitnami/kafka:3.7.0
+    image: soldevelo/kafka:3.7.1-debian-12-r0
     restart: on-failure:3
     links:
       - zookeeper

--- a/vendor_patched/github.com/segmentio/kafka-go/docker_compose_versions/docker-compose-370.yml
+++ b/vendor_patched/github.com/segmentio/kafka-go/docker_compose_versions/docker-compose-370.yml
@@ -11,7 +11,7 @@ services:
       ALLOW_ANONYMOUS_LOGIN: yes
   kafka:
     container_name: kafka
-    image: bitnami/kafka:3.7.0
+    image: soldevelo/kafka:3.7.1-debian-12-r0
     restart: on-failure:3
     links:
       - zookeeper

--- a/vendor_patched/github.com/segmentio/kafka-go/docker_compose_versions/docker-compose-400.yml
+++ b/vendor_patched/github.com/segmentio/kafka-go/docker_compose_versions/docker-compose-400.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   kafka:
     container_name: kafka
-    image: bitnami/kafka:4.0.0
+    image: soldevelo/kafka:4.0.0
     restart: on-failure:3
     ports:
       - 9092:9092


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/kafka:3.7.0` → [`soldevelo/kafka:3.7.1-debian-12-r0`](https://hub.docker.com/r/soldevelo/kafka)
- `bitnami/kafka:4.0.0` → [`soldevelo/kafka:4.0.0`](https://hub.docker.com/r/soldevelo/kafka)